### PR TITLE
Add Sanity Check Protocol feature

### DIFF
--- a/prompts/01_Manager_Agent_Core_Guides/03_Task_Assignment_Prompts_Guide.md
+++ b/prompts/01_Manager_Agent_Core_Guides/03_Task_Assignment_Prompts_Guide.md
@@ -38,6 +38,9 @@ Below is a recommended structure. You should adapt this template, adding, removi
 
 ## 3. Task Assignment
 
+*   **Mandatory First Step: Sanity Check Protocol:** You must instruct the Implementation Agent to perform the "Sanity Check Protocol" as its first action.
+    *   **Example Instruction:** `"Before you begin, perform the Sanity Check Protocol on this task. Analyze it for ambiguity, propose a clear sub-task breakdown if necessary, and wait for my approval before writing any code. If the task is already clear and unambiguous, state that and proceed."`
+    *   **Reference:** The agent's instructions for this protocol are defined in `prompts/01_Manager_Agent_Core_Guides/06_Sanity_Check_Protocol_Guide.md`.
 *   **Reference Implementation Plan:** Explicitly link the task to the `Implementation_Plan.md`. Example: "This assignment corresponds to `Phase X, Task Y, Sub-component Z` in the Implementation Plan."
 *   **Objective:** Clearly restate the specific objective of this task or sub-component, as stated in the Implementation Plan.
 *   **Detailed Action Steps (Incorporating Plan Guidance):**

--- a/prompts/01_Manager_Agent_Core_Guides/06_Sanity_Check_Protocol_Guide.md
+++ b/prompts/01_Manager_Agent_Core_Guides/06_Sanity_Check_Protocol_Guide.md
@@ -1,0 +1,19 @@
+# Sanity Check Protocol Guide
+
+## 1. Purpose
+
+The Sanity Check Protocol is a mandatory first step for an Implementation Agent upon receiving a new task. Its purpose is to mitigate "agent drift" by forcing a task analysis and breakdown *before* any code is written. This ensures the agent does not execute on an ambiguous goal.
+
+## 2. Trigger
+
+This protocol is triggered automatically whenever an Implementation Agent is assigned a new task from the `Implementation_Plan.md`.
+
+## 3. The Protocol
+
+The Implementation Agent MUST perform the following steps:
+
+1.  **Acknowledge and Announce:** State that you have received the task and are initiating the Sanity Check Protocol.
+2.  **Analyze for Ambiguity:** Read the task description and identify if it can be interpreted in multiple ways or if it involves more than one logical step.
+3.  **Propose Sub-Tasks (if necessary):** If the task is ambiguous or complex, formulate a numbered or bulleted list of smaller, more concrete "micro-tasks". Each micro-task should represent a single, unambiguous action.
+4.  **Request Approval:** Present the sub-task plan to the Project Lead (the user) for approval. You MUST NOT proceed with any work until the plan is approved.
+5.  **Proceed if Clear:** If the initial task is already simple, unambiguous, and requires no breakdown, state this clearly and announce that you are proceeding with the task as-is. 


### PR DESCRIPTION
This pull request introduces a new 'Sanity Check Protocol' to the APM framework, as per the "Suggesting Enhancements" guideline in CONTRIBUTING.md.

The protocol requires the Implementation Agent to analyze assigned tasks for ambiguity and propose a clear sub-task breakdown for approval before writing any code. This serves as a "braking mechanism" to mitigate agent scope creep and ensure the agent's work remains tightly aligned with the project plan.