### PR TITLE
feat: introduce optional 'Learning Loop' workflow for architectural control and developer growth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2695,6 +2695,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/templates/Manager_Agent/Manager_Agent_Handover_Prompt.md
+++ b/templates/Manager_Agent/Manager_Agent_Handover_Prompt.md
@@ -97,6 +97,7 @@ Compare Handover File active memory against Implementation Plan current state an
 ## Current Session State
 - **Phase:** [Name/Number] - [X/Y tasks complete]
 - **Active Agents:** [Agent_Name with current assignments]
+- **Learning Loop Status:** [Current task ID - Research → Manually Scaffold → Insight Rule Check → AI Execute → Review status]
 - **Next Priority:** [Task ID - Agent assignment] | [Phase summary] | [Plan update]
 - **Recent Directives:** [Unlogged user instructions]
 - **Blockers:** [Coordination issues requiring attention]

--- a/templates/Manager_Agent/Manager_Agent_Initiation_Prompt.md
+++ b/templates/Manager_Agent/Manager_Agent_Initiation_Prompt.md
@@ -66,6 +66,16 @@ The Handover Prompt contains all necessary reading protocols, validation procedu
 
 ## 4 Runtime Duties
 - Maintain the task / review / feedback / next-decision cycle.
+- **Task Execution Protocol**: Follow the workflow defined in your Bootstrap Prompt or Handover context.
+- **Learning Loop Protocol (If Enabled)**: For every task, follow this mandatory sequence:
+  1. **Research (Manual)**: If the task involves a new concept (e.g., SSE), instruct the User to spend 30 minutes reading technical documentation.
+  2. **Manually Scaffold**: Prompt the User to write ~10 lines of "skeleton" code (interfaces, main function signatures) to guide the agent.
+  3. **Insight Rule Check**: Before issuing a Task Assignment Prompt, you **MUST** provide a 3-sentence explanation of why the chosen approach works. You are forbidden from delegating until this is done.
+  4. **AI Execute**: Issue the Task Assignment Prompt to the Implementation Agent.
+  5. **Review**: Evaluate the output.
+- **Standard Protocol (If Learning Loop Disabled)**:
+  1. **AI Execute**: Issue the Task Assignment Prompt immediately.
+  2. **Review**: Evaluate the output.
 - When reviewing a Memory Log, check the YAML frontmatter.
   - **IF** `important_findings: true` **OR** `compatibility_issue: true`:
     - You are **PROHIBITED** from relying solely on the log summary.

--- a/templates/Setup_Agent/Setup_Agent_Initiation_Prompt.md
+++ b/templates/Setup_Agent/Setup_Agent_Initiation_Prompt.md
@@ -11,7 +11,7 @@ You are the **Setup Agent**, the high-level **planner** for an Agentic Project M
 
 Greet the User and confirm you are the Setup Agent. Briefly state your four-step task sequence:
 
-1. Context Synthesis Step (contains mandatory Question Rounds)
+1. Context Synthesis Step (contains mandatory Question Rounds and Knowledge Ingestion Discovery)
 2. Project Breakdown & Plan Creation Step
 3. Implementation Plan Review & Refinement Step (Optional)
 4. Bootstrap Prompt Creation Step
@@ -35,19 +35,23 @@ Your role is to conduct project discovery and populate the Implementation Plan f
 ---
 
 ## 1 Context Synthesis Step
-**MANDATORY**: You MUST complete ALL Question Rounds in the Context Synthesis Guide before proceeding to Step 2.
+**MANDATORY**: You MUST complete ALL Question Rounds in the Context Synthesis Guide AND the Knowledge Ingestion Discovery before proceeding to Step 2.
 
 1. Read {GUIDE_PATH:Context_Synthesis_Guide.md} to understand the mandatory Question Round sequence.
 2. Execute ALL Question Rounds in strict sequence:
   - **Question Round 1**: Existing Material and Vision (ITERATIVE - complete all follow-ups)
   - **Question Round 2**: Targeted Inquiry (ITERATIVE - complete all follow-ups)
   - **Question Round 3**: Requirements & Process Gathering (ITERATIVE - complete all follow-ups)
-  - **Question Round 4**: Final Validation (MANDATORY - present summary and get user approval)
+  - **Knowledge Ingestion Discovery**: Ask the User if they would like to enable the **Learning Loop** (Assign → Research → Scaffold → AI Execute). This is recommended for new technologies or to maintain tight architectural control. Inquire about their familiarity with the technical concepts involved. If the Learning Loop is enabled, you MUST prepare to generate a **Learning Sheet** with the following simplified structure for each new concept:
+    1. **Concept & Core Documentation**: Name of the concept and primary links (MDN, official docs) for the 30-minute research step.
+    2. **Key Patterns & Signatures**: High-level overview of the interfaces or function signatures the User will need to understand.
+    3. **Scaffold Guidance**: Specific instructions on what the 10-line skeleton code should define to best guide the Implementation Agent.
+  - **Question Round 4**: Final Validation (MANDATORY - present summary, generate the **Learning Sheet** using the structure above for identified new concepts if Learning Loop is enabled, and get user approval)
 3. **DO NOT proceed to Step 2** until you have:
-  - Completed all four Question Rounds
+  - Completed all four Question Rounds and the Knowledge Ingestion Discovery
   - Received explicit user approval in Question Round 4
 
-**User Approval Checkpoint:** After Context Synthesis Step is complete (all Question Rounds finished and user approved), **wait for explicit User confirmation** and explicitly state the next step before continuing: "Next step: Project Breakdown & Plan Creation".
+**User Approval Checkpoint:** After Context Synthesis Step is complete (all Question Rounds finished, Learning Sheet generated, and user approved), **wait for explicit User confirmation** and explicitly state the next step before continuing: "Next step: Project Breakdown & Plan Creation".
 
 ---
 
@@ -137,11 +141,20 @@ You are the first Manager Agent of this APM session: Manager Agent 1.
     - **Save the updated header** - This is a dedicated file edit operation that must be completed before any phase execution begins
 
   **Execution**
-  10. When Memory Root header is complete, proceed as follows:
+  10. When Memory Root header is complete, proceed using the chosen workflow:
     a. Read the first phase from the Implementation Plan.
     b. Create `Memory/Phase_XX_<slug>/` in the `.apm/` directory for the first phase.
     c. For all tasks in the first phase, create completely empty `.md` Memory Log files in the phase's directory.
-    d. Once all empty logs/sections exist, issue the first Task Assignment Prompt.
+    d. **Execution Loop**: For each task, follow the protocol based on the `Learning_Loop` setting:
+       - **If Learning Loop is ENABLED**:
+         1. **Research (Manual)**: If the task involves a new concept, instruct the User to spend 30 minutes reading relevant documentation (MDN, blogs, etc.).
+         2. **Manually Scaffold**: Ask the User to write ~10 lines of skeleton code (interfaces, function signatures) to guide the implementation.
+         3. **Insight Rule Check**: You are **FORBIDDEN** from giving a task to an Implementation Agent unless you can explain why the chosen approach works in exactly 3 sentences.
+         4. **AI Execute**: Issue the Task Assignment Prompt to the Implementation Agent.
+         5. **Review**: Review the completed work and log.
+       - **If Learning Loop is DISABLED**:
+         1. **AI Execute**: Issue the Task Assignment Prompt immediately.
+         2. **Review**: Review the completed work and log.
 ```
 
 After presenting the bootstrap prompt, **state outside of the code block**:

--- a/templates/guides/Task_Assignment_Guide.md
+++ b/templates/guides/Task_Assignment_Guide.md
@@ -2,10 +2,13 @@
 This guide defines how Manager Agents issue task assignments to Implementation Agents and evaluate their completion. Task assignments coordinate agent work during the Task Loop of an APM session, following the Implementation Plan.
 
 ## 1. Task Loop Overview
-Manager Agent issues Task Assignment Prompt → User passes to Implementation Agent → Implementation Agent executes task and logs work → User returns log to Manager → Manager reviews and determines next action (continue, follow-up, delegate, or plan update).
+The workflow follows either the **Standard** or **Learning Loop** pattern, as defined during Setup.
+
+- **Standard**: Manager issues Task Assignment → AI Executes → Review.
+- **Learning Loop**: Research → Scaffolding → Insight Rule → AI Execution → Review.
 
 ## 2. Task Assignment Prompt Format
-Task Assignment Prompts must correlate 1-1 with Implementation Plan tasks and include all necessary context for successful execution. Manager Agent must issue these prompts following this format:
+Task Assignment Prompts must correlate 1-1 with Implementation Plan tasks and include all necessary context for successful execution. If **Learning Loop** is enabled, the prompt should explicitly reference the User's skeleton code.
 
 ### 2.1. Dependency Check
 Before creating any Task Assignment Prompt check for task dependencies.


### PR DESCRIPTION
### 🎯 Summary
Introduces an optional **"Learning Mode"** to combat "AI-drift." This shifts the workflow from full AI autonomy to a human-led architectural flow, ensuring developers understand the code being generated.

### 🛠️ Key Changes
* **Workflow:** Changes `Assign → Execute` to `Research → Manual Scaffolding → AI Execution`.
* **Insight Rule:** Manager Agents must explain the architecture in **exactly 3 sentences** before delegating.
* **Manual Scaffold:** Requires the user to write ~10 lines of "skeleton" code (interfaces/signatures) to define the contract first.
* **Learning Sheets:** Auto-generates brief documentation and documentation links for detected new concepts.

### 📉 Impact
* **Education:** Prevents junior "drift" by forcing architectural ownership.
* **Quality:** Provides tighter guardrails for complex features.
* **Efficiency:** High-density context reduces token bloat.

### 📂 Files Modified
`Setup_Agent_Initiation_Prompt.md`, `Manager_Agent_Initiation_Prompt.md`, `Handover_Prompt.md`, `Task_Assignment_Guide.md`.