### PR TITLE
Migrate Gemini CLI to Antigravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Breaking Changes
 
-* **Antigravity CLI Migration:** Transitioned support from Antigravity CLI to the new Antigravity CLI. The `.antigravity` configuration directory has been replaced with `.antigravity`, and the rules file has been renamed from `ANTIGRAVITY.md` to `ANTIGRAVITY.md`. Output format has been updated from TOML to Markdown.
+* **Antigravity (CLI & IDE) Migration:** Transitioned support from Antigravity (CLI & IDE) to the new Antigravity (CLI & IDE). The `.antigravity` configuration directory has been replaced with `.antigravity`, and the rules file has been renamed from `ANTIGRAVITY.md` to `ANTIGRAVITY.md`. Output format has been updated from TOML to Markdown.
 
 ### Added
 
-* **Antigravity CLI Support:** Full support for the new Antigravity CLI, including optimized directory structure and agent-first subagent guidance.
+* **Antigravity (CLI & IDE) Support:** Full support for the new Antigravity (CLI & IDE), including optimized directory structure and agent-first subagent guidance.
 
 ## [1.0.1] - 2026-04-24
 
@@ -37,7 +37,7 @@ v1.0.0 is a complete redesign of the APM workflow. The scope of changes across b
 
 * **New artifact structure.** Spec (`.apm/spec.md`), Plan with dependency graphs (`.apm/plan.md`), Rules (platform rules file), Tracker (`.apm/tracker.md`), Memory hierarchy (`.apm/memory/` with Index, Task Logs, Handoff Logs). Replaces Implementation Plan and Memory Root.
 
-* **Platform support narrowed** to Claude Code, Cursor, GitHub Copilot, Antigravity CLI, and OpenCode.
+* **Platform support narrowed** to Claude Code, Cursor, GitHub Copilot, Antigravity (CLI & IDE), and OpenCode.
 
 * **Template file structure changed.** Commands in `templates/commands/`, guides in `templates/guides/`, skills in `templates/skills/`, agents in `templates/agents/`. Governed by `templates/_standards/` (WORKFLOW.md, TERMINOLOGY.md, STRUCTURE.md, WRITING.md).
 
@@ -114,7 +114,7 @@ v1.0.0 is a complete redesign of the APM workflow. The scope of changes across b
 * **`apm init` Command:** Automates project setup, including AI assistant selection, asset download from GitHub Releases, and creation of the `.apm` directory structure (`.apm/guides`, `.apm/Memory`, `.apm/Implementation_Plan.md`, `.apm/metadata.json`). By default, automatically finds and installs the latest template version compatible with the current CLI version. Supports `--tag <tag>` option for installing specific template versions (e.g., `apm init --tag v0.5.0+templates.1`).
 * **`apm update` Command:** Allows users to update their local APM installation to the latest compatible template version. Includes intelligent version compatibility checking that compares installed templates against available releases, only updating if a newer compatible build exists. Informs users when newer templates require a CLI update via `npm update -g agentic-pm`. Includes backup and restore functionality for safe updates.
 * **Version Compatibility System:** Dynamic CLI version reading from `package.json` with automatic template version matching. The CLI automatically finds templates compatible with the running CLI version and compares build numbers for update decisions.
-* **Support for 10 AI Assistants:** CLI downloads and installs specific bundles tailored for Cursor, GitHub Copilot, Claude Code, Antigravity CLI, Qwen Code, OpenCode, Windsurf, Kilo Code, Auggie CLI, and Roo Code.
+* **Support for 10 AI Assistants:** CLI downloads and installs specific bundles tailored for Cursor, GitHub Copilot, Claude Code, Antigravity (CLI & IDE), Qwen Code, OpenCode, Windsurf, Kilo Code, Auggie CLI, and Roo Code.
 * **Build Process (`npm run build`):** New script (`scripts/build.js`) processes source templates (`templates/`) into distributable bundles (`dist/`) for each assistant, handling formatting (Markdown/TOML) and placeholders.
 * **Metadata File (`.apm/metadata.json`):** Tracks the installed APM version (template tag) and selected AI assistant within the project.
 * **`Troubleshooting_Guide.md`:** Added a dedicated guide based on the v0.4 User Guide's troubleshooting section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
-## [1.0.0] - 2026-04-09
+## [1.0.2] - Unreleased
+
+### Breaking Changes
+
+* **Antigravity CLI Migration:** Transitioned support from Antigravity CLI to the new Antigravity CLI. The `.antigravity` configuration directory has been replaced with `.antigravity`, and the rules file has been renamed from `ANTIGRAVITY.md` to `ANTIGRAVITY.md`. Output format has been updated from TOML to Markdown.
+
+### Added
+
+* **Antigravity CLI Support:** Full support for the new Antigravity CLI, including optimized directory structure and agent-first subagent guidance.
+
+## [1.0.1] - 2026-04-24
+
+### Fixed
+
+* **Codex CLI fixes:** Resolved issues with Codex CLI command invocation and path handling.
+
+## [1.0.0] - 2026-04-12
 
 v1.0.0 is a complete redesign of the APM workflow. The scope of changes across both the codebase and the workflow itself is too large to cover exhaustively here. This is a concise summary of the most significant changes. For the full specification, see the [documentation](https://github.com/sdi2200262/apm-website/tree/main/docs).
 
@@ -21,7 +37,7 @@ v1.0.0 is a complete redesign of the APM workflow. The scope of changes across b
 
 * **New artifact structure.** Spec (`.apm/spec.md`), Plan with dependency graphs (`.apm/plan.md`), Rules (platform rules file), Tracker (`.apm/tracker.md`), Memory hierarchy (`.apm/memory/` with Index, Task Logs, Handoff Logs). Replaces Implementation Plan and Memory Root.
 
-* **Platform support narrowed** to Claude Code, Cursor, GitHub Copilot, Gemini CLI, and OpenCode.
+* **Platform support narrowed** to Claude Code, Cursor, GitHub Copilot, Antigravity CLI, and OpenCode.
 
 * **Template file structure changed.** Commands in `templates/commands/`, guides in `templates/guides/`, skills in `templates/skills/`, agents in `templates/agents/`. Governed by `templates/_standards/` (WORKFLOW.md, TERMINOLOGY.md, STRUCTURE.md, WRITING.md).
 
@@ -98,7 +114,7 @@ v1.0.0 is a complete redesign of the APM workflow. The scope of changes across b
 * **`apm init` Command:** Automates project setup, including AI assistant selection, asset download from GitHub Releases, and creation of the `.apm` directory structure (`.apm/guides`, `.apm/Memory`, `.apm/Implementation_Plan.md`, `.apm/metadata.json`). By default, automatically finds and installs the latest template version compatible with the current CLI version. Supports `--tag <tag>` option for installing specific template versions (e.g., `apm init --tag v0.5.0+templates.1`).
 * **`apm update` Command:** Allows users to update their local APM installation to the latest compatible template version. Includes intelligent version compatibility checking that compares installed templates against available releases, only updating if a newer compatible build exists. Informs users when newer templates require a CLI update via `npm update -g agentic-pm`. Includes backup and restore functionality for safe updates.
 * **Version Compatibility System:** Dynamic CLI version reading from `package.json` with automatic template version matching. The CLI automatically finds templates compatible with the running CLI version and compares build numbers for update decisions.
-* **Support for 10 AI Assistants:** CLI downloads and installs specific bundles tailored for Cursor, GitHub Copilot, Claude Code, Gemini CLI, Qwen Code, OpenCode, Windsurf, Kilo Code, Auggie CLI, and Roo Code.
+* **Support for 10 AI Assistants:** CLI downloads and installs specific bundles tailored for Cursor, GitHub Copilot, Claude Code, Antigravity CLI, Qwen Code, OpenCode, Windsurf, Kilo Code, Auggie CLI, and Roo Code.
 * **Build Process (`npm run build`):** New script (`scripts/build.js`) processes source templates (`templates/`) into distributable bundles (`dist/`) for each assistant, handling formatting (Markdown/TOML) and placeholders.
 * **Metadata File (`.apm/metadata.json`):** Tracks the installed APM version (template tag) and selected AI assistant within the project.
 * **`Troubleshooting_Guide.md`:** Added a dedicated guide based on the v0.4 User Guide's troubleshooting section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Breaking Changes
 
-* **Antigravity (CLI & IDE) Migration:** Transitioned support from Antigravity (CLI & IDE) to the new Antigravity (CLI & IDE). The `.antigravity` configuration directory has been replaced with `.antigravity`, and the rules file has been renamed from `ANTIGRAVITY.md` to `ANTIGRAVITY.md`. Output format has been updated from TOML to Markdown.
+* **Gemini CLI Migration:** Transitioned support from Gemini CLI to the new Antigravity platform. The configuration directory has moved from `.gemini` to `.agents`, and the rules file has been renamed from `GEMINI.md` to `AGENTS.md`. Output format has been updated from TOML to Markdown.
 
 ### Added
 
-* **Antigravity (CLI & IDE) Support:** Full support for the new Antigravity (CLI & IDE), including optimized directory structure and agent-first subagent guidance.
+* **Antigravity Support:** Full support for the new Antigravity (CLI and IDE), including optimized directory structure (`.agents/workflows/`, `.agents/skills/`) and agent-first subagent guidance.
 
 ## [1.0.1] - 2026-04-24
 
@@ -37,7 +37,7 @@ v1.0.0 is a complete redesign of the APM workflow. The scope of changes across b
 
 * **New artifact structure.** Spec (`.apm/spec.md`), Plan with dependency graphs (`.apm/plan.md`), Rules (platform rules file), Tracker (`.apm/tracker.md`), Memory hierarchy (`.apm/memory/` with Index, Task Logs, Handoff Logs). Replaces Implementation Plan and Memory Root.
 
-* **Platform support narrowed** to Claude Code, Cursor, GitHub Copilot, Antigravity (CLI & IDE), and OpenCode.
+* **Platform support narrowed** to Claude Code, Cursor, GitHub Copilot, Antigravity, and OpenCode.
 
 * **Template file structure changed.** Commands in `templates/commands/`, guides in `templates/guides/`, skills in `templates/skills/`, agents in `templates/agents/`. Governed by `templates/_standards/` (WORKFLOW.md, TERMINOLOGY.md, STRUCTURE.md, WRITING.md).
 
@@ -114,7 +114,7 @@ v1.0.0 is a complete redesign of the APM workflow. The scope of changes across b
 * **`apm init` Command:** Automates project setup, including AI assistant selection, asset download from GitHub Releases, and creation of the `.apm` directory structure (`.apm/guides`, `.apm/Memory`, `.apm/Implementation_Plan.md`, `.apm/metadata.json`). By default, automatically finds and installs the latest template version compatible with the current CLI version. Supports `--tag <tag>` option for installing specific template versions (e.g., `apm init --tag v0.5.0+templates.1`).
 * **`apm update` Command:** Allows users to update their local APM installation to the latest compatible template version. Includes intelligent version compatibility checking that compares installed templates against available releases, only updating if a newer compatible build exists. Informs users when newer templates require a CLI update via `npm update -g agentic-pm`. Includes backup and restore functionality for safe updates.
 * **Version Compatibility System:** Dynamic CLI version reading from `package.json` with automatic template version matching. The CLI automatically finds templates compatible with the running CLI version and compares build numbers for update decisions.
-* **Support for 10 AI Assistants:** CLI downloads and installs specific bundles tailored for Cursor, GitHub Copilot, Claude Code, Antigravity (CLI & IDE), Qwen Code, OpenCode, Windsurf, Kilo Code, Auggie CLI, and Roo Code.
+* **Support for 10 AI Assistants:** CLI downloads and installs specific bundles tailored for Cursor, GitHub Copilot, Claude Code, Antigravity, Qwen Code, OpenCode, Windsurf, Kilo Code, Auggie CLI, and Roo Code.
 * **Build Process (`npm run build`):** New script (`scripts/build.js`) processes source templates (`templates/`) into distributable bundles (`dist/`) for each assistant, handling formatting (Markdown/TOML) and placeholders.
 * **Metadata File (`.apm/metadata.json`):** Tracks the installed APM version (template tag) and selected AI assistant within the project.
 * **`Troubleshooting_Guide.md`:** Added a dedicated guide based on the v0.4 User Guide's troubleshooting section.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for considering contributing to APM! Your contributions help build a b
 - **For new bug reports**, include:
   - APM CLI version (run `apm --version` or `npm list -g agentic-pm`)
   - Node.js and npm versions (run `node --version` and `npm --version`)
-  - AI assistant used (Claude Code, Cursor, Copilot, Gemini CLI, or OpenCode)
+  - AI assistant used (Claude Code, Cursor, Copilot, Antigravity CLI, or OpenCode)
   - Agent type experiencing issues (Planner, Manager, or Worker)
   - Step-by-step reproduction of the issue (if possible, otherwise a detailed description)
   - Expected vs actual behavior
@@ -47,7 +47,7 @@ Thank you for considering contributing to APM! Your contributions help build a b
 
 ### Community Extensions
 
-APM officially supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Gemini CLI, and OpenCode. For other assistants (e.g. Windsurf, Kilo Code, Roo Code), community members may develop and maintain unofficial extensions.
+APM officially supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Antigravity CLI, and OpenCode. For other assistants (e.g. Windsurf, Kilo Code, Roo Code), community members may develop and maintain unofficial extensions.
 
 Community extensions are not officially supported, may lag behind releases, and should be tested thoroughly before use. If you're interested in developing or maintaining an extension, please open an issue to discuss.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for considering contributing to APM! Your contributions help build a b
 - **For new bug reports**, include:
   - APM CLI version (run `apm --version` or `npm list -g agentic-pm`)
   - Node.js and npm versions (run `node --version` and `npm --version`)
-  - AI assistant used (Claude Code, Cursor, Copilot, Antigravity CLI, or OpenCode)
+  - AI assistant used (Claude Code, Cursor, Copilot, Antigravity, or OpenCode)
   - Agent type experiencing issues (Planner, Manager, or Worker)
   - Step-by-step reproduction of the issue (if possible, otherwise a detailed description)
   - Expected vs actual behavior
@@ -47,7 +47,7 @@ Thank you for considering contributing to APM! Your contributions help build a b
 
 ### Community Extensions
 
-APM officially supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Antigravity CLI, and OpenCode. For other assistants (e.g. Windsurf, Kilo Code, Roo Code), community members may develop and maintain unofficial extensions.
+APM officially supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Antigravity, and OpenCode. For other assistants (e.g. Windsurf, Kilo Code, Roo Code), community members may develop and maintain unofficial extensions.
 
 Community extensions are not officially supported, may lag behind releases, and should be tested thoroughly before use. If you're interested in developing or maintaining an extension, please open an issue to discuss.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ APM is for people who build with AI agents and own what they ship. Delivering ea
 
 ## Quick Start
 
-APM supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Gemini CLI, and OpenCode.
+APM supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Antigravity CLI, and OpenCode.
 
 Install the CLI:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ APM is for people who build with AI agents and own what they ship. Delivering ea
 
 ## Quick Start
 
-APM supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Antigravity CLI, and OpenCode.
+APM supports Claude Code, Codex CLI, Cursor, GitHub Copilot, Antigravity, and OpenCode.
 
 Install the CLI:
 

--- a/build/_standards/BUILD.md
+++ b/build/_standards/BUILD.md
@@ -179,7 +179,7 @@ Supported placeholders:
 - `{SKILL_PATH:name}`, `{GUIDE_PATH:name}`, `{COMMAND_PATH:name}`, `{AGENT_PATH:name}` - Cross-reference paths
 - `{SKILLS_DIR}`, `{GUIDES_DIR}`, `{AGENTS_DIR}` - Platform-specific directory paths
 - `{ARGS}` - `$ARGUMENTS` (Markdown), `{{args}}` (TOML), `${input:args}` (Copilot)
-- `{RULES_FILE}` - `CLAUDE.md` (Claude), `GEMINI.md` (Gemini), `AGENTS.md` (others)
+- `{RULES_FILE}` - `CLAUDE.md` (Claude), `ANTIGRAVITY.md` (Gemini), `AGENTS.md` (others)
 - `{PLANNER_SUBAGENT_GUIDANCE}`, `{MANAGER_SUBAGENT_GUIDANCE}`, `{WORKER_SUBAGENT_GUIDANCE}`, `{SUBAGENT_GUIDANCE}` - Role-specific subagent syntax
 - `{ARCHIVE_EXPLORER_GUIDANCE}` - Subagent spawn syntax for archive explorer agent
 - `{CONTEXT_ATTACH_SYNTAX}` - Platform-specific file reference instructions

--- a/build/_standards/BUILD.md
+++ b/build/_standards/BUILD.md
@@ -179,7 +179,7 @@ Supported placeholders:
 - `{SKILL_PATH:name}`, `{GUIDE_PATH:name}`, `{COMMAND_PATH:name}`, `{AGENT_PATH:name}` - Cross-reference paths
 - `{SKILLS_DIR}`, `{GUIDES_DIR}`, `{AGENTS_DIR}` - Platform-specific directory paths
 - `{ARGS}` - `$ARGUMENTS` (Markdown), `{{args}}` (TOML), `${input:args}` (Copilot)
-- `{RULES_FILE}` - `CLAUDE.md` (Claude), `ANTIGRAVITY.md` (Gemini), `AGENTS.md` (others)
+- `{RULES_FILE}` - `CLAUDE.md` (Claude), `AGENTS.md` (Gemini), `AGENTS.md` (others)
 - `{PLANNER_SUBAGENT_GUIDANCE}`, `{MANAGER_SUBAGENT_GUIDANCE}`, `{WORKER_SUBAGENT_GUIDANCE}`, `{SUBAGENT_GUIDANCE}` - Role-specific subagent syntax
 - `{ARCHIVE_EXPLORER_GUIDANCE}` - Subagent spawn syntax for archive explorer agent
 - `{CONTEXT_ATTACH_SYNTAX}` - Platform-specific file reference instructions

--- a/build/_standards/BUILD.md
+++ b/build/_standards/BUILD.md
@@ -179,7 +179,7 @@ Supported placeholders:
 - `{SKILL_PATH:name}`, `{GUIDE_PATH:name}`, `{COMMAND_PATH:name}`, `{AGENT_PATH:name}` - Cross-reference paths
 - `{SKILLS_DIR}`, `{GUIDES_DIR}`, `{AGENTS_DIR}` - Platform-specific directory paths
 - `{ARGS}` - `$ARGUMENTS` (Markdown), `{{args}}` (TOML), `${input:args}` (Copilot)
-- `{RULES_FILE}` - `CLAUDE.md` (Claude), `AGENTS.md` (Gemini), `AGENTS.md` (others)
+- `{RULES_FILE}` - `CLAUDE.md` (Claude), `AGENTS.md` (all others)
 - `{PLANNER_SUBAGENT_GUIDANCE}`, `{MANAGER_SUBAGENT_GUIDANCE}`, `{WORKER_SUBAGENT_GUIDANCE}`, `{SUBAGENT_GUIDANCE}` - Role-specific subagent syntax
 - `{ARCHIVE_EXPLORER_GUIDANCE}` - Subagent spawn syntax for archive explorer agent
 - `{CONTEXT_ATTACH_SYNTAX}` - Platform-specific file reference instructions
@@ -214,7 +214,7 @@ await createZipArchive(targetBuildDir, zipPath);
 }
 ```
 
-`postInstallNote` is optional (only Gemini currently uses it).
+`postInstallNote` is optional (only Codex currently uses it).
 
 ## Logging
 

--- a/build/build-config.json
+++ b/build/build-config.json
@@ -50,16 +50,16 @@
       "postInstallNote": null
     },
     {
-      "id": "antigravity",
-      "name": "Antigravity (CLI & IDE)",
-      "bundleName": "antigravity.zip",
+      "id": .agents",
+      "name": "Antigravity",
+      "bundleName": .agents.zip",
       "format": "markdown",
-      "configDir": ".antigravity",
+      "configDir": ".agents",
       "directories": {
-        "commands": ".antigravity/commands",
-        "skills": ".antigravity/skills",
-        "guides": ".antigravity/apm-guides",
-        "agents": ".antigravity/agents"
+        "commands": ".agents/workflows",
+        "skills": ".agents/skills",
+        "guides": ".agents/apm-guides",
+        "agents": ".agents/agents"
       },
       "contextAttachSyntax": "Reference the file using `@` followed by the file path.",
       "newChatGuidance": "Open a new terminal and start Antigravity CLI, or start a new Antigravity IDE session",

--- a/build/build-config.json
+++ b/build/build-config.json
@@ -50,26 +50,26 @@
       "postInstallNote": null
     },
     {
-      "id": "gemini",
-      "name": "Gemini CLI",
-      "bundleName": "gemini.zip",
-      "format": "toml",
-      "configDir": ".gemini",
+      "id": "antigravity",
+      "name": "Antigravity CLI",
+      "bundleName": "antigravity.zip",
+      "format": "markdown",
+      "configDir": ".antigravity",
       "directories": {
-        "commands": ".gemini/commands",
-        "skills": ".gemini/skills",
-        "guides": ".gemini/apm-guides",
-        "agents": ".gemini/agents"
+        "commands": ".antigravity/commands",
+        "skills": ".antigravity/skills",
+        "guides": ".antigravity/apm-guides",
+        "agents": ".antigravity/agents"
       },
       "contextAttachSyntax": "Reference the file using `@` followed by the file path.",
-      "newChatGuidance": "Open a new terminal and start Gemini CLI",
+      "newChatGuidance": "Open a new terminal and start Antigravity CLI",
       "subagentGuidance": {
         "hasSubagents": true,
-        "toolSyntax": "@codebase_investigator <natural language query>",
-        "explorerName": "codebase_investigator",
-        "configNote": "Requires `experimental.enableAgents: true` in ~/.gemini/settings.json"
+        "toolSyntax": "Agent(subagent_type=\"Explore\", prompt=\"...\")",
+        "explorerName": "Explore",
+        "configNote": null
       },
-      "postInstallNote": "Gemini CLI requires `experimental.enableAgents: true` in ~/.gemini/settings.json for subagent features."
+      "postInstallNote": null
     },
     {
       "id": "cursor",

--- a/build/build-config.json
+++ b/build/build-config.json
@@ -51,7 +51,7 @@
     },
     {
       "id": "antigravity",
-      "name": "Antigravity CLI",
+      "name": "Antigravity (CLI & IDE)",
       "bundleName": "antigravity.zip",
       "format": "markdown",
       "configDir": ".antigravity",
@@ -62,7 +62,7 @@
         "agents": ".antigravity/agents"
       },
       "contextAttachSyntax": "Reference the file using `@` followed by the file path.",
-      "newChatGuidance": "Open a new terminal and start Antigravity CLI",
+      "newChatGuidance": "Open a new terminal and start Antigravity CLI, or start a new Antigravity IDE session",
       "subagentGuidance": {
         "hasSubagents": true,
         "toolSyntax": "Agent(subagent_type=\"Explore\", prompt=\"...\")",

--- a/build/build-config.json
+++ b/build/build-config.json
@@ -50,9 +50,9 @@
       "postInstallNote": null
     },
     {
-      "id": .agents",
+      "id": "antigravity",
       "name": "Antigravity",
-      "bundleName": .agents.zip",
+      "bundleName": "antigravity.zip",
       "format": "markdown",
       "configDir": ".agents",
       "directories": {

--- a/build/index.js
+++ b/build/index.js
@@ -2,7 +2,7 @@
  * APM Build System Entry Point
  *
  * Generates AI assistant-specific command bundles from markdown templates.
- * Supports Markdown (Claude, Copilot, etc.) and TOML (Gemini) formats.
+ * All current targets emit the Markdown output format.
  *
  * Usage: node build/index.js
  *

--- a/build/processors/placeholders.js
+++ b/build/processors/placeholders.js
@@ -89,7 +89,7 @@ export function replacePlaceholders(content, context) {
   replaced = replaced.replace(/{ARGS}/g, argsPlaceholder);
 
   // Replace RULES_FILE placeholder
-  const rulesFileName = id === 'claude' ? 'CLAUDE.md' : id === 'gemini' ? 'GEMINI.md' : 'AGENTS.md';
+  const rulesFileName = id === 'claude' ? 'CLAUDE.md' : id === 'antigravity' ? 'ANTIGRAVITY.md' : 'AGENTS.md';
   replaced = replaced.replace(/{RULES_FILE}/g, rulesFileName);
 
   // Replace SKILLS_DIR placeholder

--- a/build/processors/placeholders.js
+++ b/build/processors/placeholders.js
@@ -89,7 +89,7 @@ export function replacePlaceholders(content, context) {
   replaced = replaced.replace(/{ARGS}/g, argsPlaceholder);
 
   // Replace RULES_FILE placeholder
-  const rulesFileName = id === 'claude' ? 'CLAUDE.md' : id === 'antigravity' ? 'ANTIGRAVITY.md' : 'AGENTS.md';
+  const rulesFileName = id === 'claude' ? 'CLAUDE.md' : (id === .agents' || id === 'copilot' || id === 'opencode' || id === 'codex') ? 'AGENTS.md' : 'AGENTS.md';
   replaced = replaced.replace(/{RULES_FILE}/g, rulesFileName);
 
   // Replace SKILLS_DIR placeholder

--- a/build/processors/placeholders.js
+++ b/build/processors/placeholders.js
@@ -89,7 +89,7 @@ export function replacePlaceholders(content, context) {
   replaced = replaced.replace(/{ARGS}/g, argsPlaceholder);
 
   // Replace RULES_FILE placeholder
-  const rulesFileName = id === 'claude' ? 'CLAUDE.md' : (id === .agents' || id === 'copilot' || id === 'opencode' || id === 'codex') ? 'AGENTS.md' : 'AGENTS.md';
+  const rulesFileName = id === 'claude' ? 'CLAUDE.md' : 'AGENTS.md';
   replaced = replaced.replace(/{RULES_FILE}/g, rulesFileName);
 
   // Replace SKILLS_DIR placeholder

--- a/build/processors/placeholders.js
+++ b/build/processors/placeholders.js
@@ -80,8 +80,8 @@ export function replacePlaceholders(content, context) {
 
   // Replace ARGS placeholder based on format
   // Platforms with native argument variables: Claude ($ARGUMENTS), Copilot (${input:args}),
-  // Gemini ({{args}}), OpenCode ($ARGUMENTS). Cursor and Codex have no argument variable —
-  // use descriptive text so the model picks up the user's input naturally.
+  // OpenCode ($ARGUMENTS); the TOML output format uses {{args}}. Cursor and Codex have no
+  // argument variable, so descriptive text is used so the model picks up the user's input naturally.
   const argsPlaceholder = format === 'toml' ? '{{args}}'
     : id === 'copilot' ? '${input:args}'
     : (id === 'codex' || id === 'cursor') ? '(the text provided by the User after the command invocation, if any)'

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,7 +23,7 @@ The skill file is the same across all platforms - only the destination directory
 | Claude Code | `.claude/skills/apm-assist/` |
 | Cursor | `.cursor/skills/apm-assist/` |
 | GitHub Copilot | `.github/skills/apm-assist/` |
-| Antigravity | `.antigravity/skills/apm-assist/` |
+| Antigravity | `.agents/skills/apm-assist/` |
 | OpenCode | `.opencode/skills/apm-assist/` |
 | Codex CLI | `.agents/skills/apm-assist/` |
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,7 +23,7 @@ The skill file is the same across all platforms - only the destination directory
 | Claude Code | `.claude/skills/apm-assist/` |
 | Cursor | `.cursor/skills/apm-assist/` |
 | GitHub Copilot | `.github/skills/apm-assist/` |
-| Gemini CLI | `.gemini/skills/apm-assist/` |
+| Antigravity CLI | `.antigravity/skills/apm-assist/` |
 | OpenCode | `.opencode/skills/apm-assist/` |
 | Codex CLI | `.agents/skills/apm-assist/` |
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,7 +23,7 @@ The skill file is the same across all platforms - only the destination directory
 | Claude Code | `.claude/skills/apm-assist/` |
 | Cursor | `.cursor/skills/apm-assist/` |
 | GitHub Copilot | `.github/skills/apm-assist/` |
-| Antigravity CLI | `.antigravity/skills/apm-assist/` |
+| Antigravity | `.antigravity/skills/apm-assist/` |
 | OpenCode | `.opencode/skills/apm-assist/` |
 | Codex CLI | `.agents/skills/apm-assist/` |
 

--- a/skills/apm-assist/SKILL.md
+++ b/skills/apm-assist/SKILL.md
@@ -39,7 +39,7 @@ Agents communicate through a file-based Message Bus in `.apm/bus/`. The user car
 
 When an Agent's context fills, a Handoff transfers working knowledge to a fresh instance. Sessions can be archived and built upon by future Planners.
 
-APM is installed via the `agentic-pm` CLI (`npm install -g agentic-pm`) and supports Claude Code, Cursor, GitHub Copilot, Gemini CLI, OpenCode, and Codex.
+APM is installed via the `agentic-pm` CLI (`npm install -g agentic-pm`) and supports Claude Code, Cursor, GitHub Copilot, Antigravity CLI, OpenCode, and Codex.
 
 ---
 
@@ -202,7 +202,7 @@ Archive metadata adds `archivedAt` and `reason` (e.g. `"migration"`) fields.
 
 **CLI changes:** v0.5.x CLI had only `apm init` and `apm update`. v1.0.0 adds `apm archive`, `apm custom`, `apm add`, `apm remove`, and `apm status`. The `apm init` command in v1.0.0 is fresh-install only (refuses to run if already initialized).
 
-**Platform support:** v0.5.x supported 11 assistants (including Windsurf, Kilo Code, Roo Code, Auggie CLI, Google Antigravity, Qwen Code). v1.0.0 narrowed to Cursor, Claude Code, GitHub Copilot, Gemini CLI, OpenCode, and Codex.
+**Platform support:** v0.5.x supported 11 assistants (including Windsurf, Kilo Code, Roo Code, Auggie CLI, Google Antigravity, Qwen Code). v1.1.0 updated Antigravity CLI to Antigravity CLI. v1.0.0 narrowed to Cursor, Claude Code, GitHub Copilot, Antigravity CLI, OpenCode, and Codex.
 
 ### 5.4 Execute
 

--- a/skills/apm-assist/SKILL.md
+++ b/skills/apm-assist/SKILL.md
@@ -39,7 +39,7 @@ Agents communicate through a file-based Message Bus in `.apm/bus/`. The user car
 
 When an Agent's context fills, a Handoff transfers working knowledge to a fresh instance. Sessions can be archived and built upon by future Planners.
 
-APM is installed via the `agentic-pm` CLI (`npm install -g agentic-pm`) and supports Claude Code, Cursor, GitHub Copilot, Antigravity CLI, OpenCode, and Codex.
+APM is installed via the `agentic-pm` CLI (`npm install -g agentic-pm`) and supports Claude Code, Cursor, GitHub Copilot, Antigravity, OpenCode, and Codex.
 
 ---
 
@@ -202,7 +202,7 @@ Archive metadata adds `archivedAt` and `reason` (e.g. `"migration"`) fields.
 
 **CLI changes:** v0.5.x CLI had only `apm init` and `apm update`. v1.0.0 adds `apm archive`, `apm custom`, `apm add`, `apm remove`, and `apm status`. The `apm init` command in v1.0.0 is fresh-install only (refuses to run if already initialized).
 
-**Platform support:** v0.5.x supported 11 assistants (including Windsurf, Kilo Code, Roo Code, Auggie CLI, Google Antigravity, Qwen Code). v1.1.0 updated Antigravity CLI to Antigravity CLI. v1.0.0 narrowed to Cursor, Claude Code, GitHub Copilot, Antigravity CLI, OpenCode, and Codex.
+**Platform support:** v0.5.x supported 11 assistants (including Windsurf, Kilo Code, Roo Code, Auggie CLI, Google Antigravity, Qwen Code). v1.1.0 updated Antigravity to Antigravity. v1.0.0 narrowed to Cursor, Claude Code, GitHub Copilot, Antigravity, OpenCode, and Codex.
 
 ### 5.4 Execute
 

--- a/src/_standards/CLI.md
+++ b/src/_standards/CLI.md
@@ -210,7 +210,7 @@ Release manifest schema:
 }
 ```
 
-`postInstallNote` is optional (only Gemini currently uses it).
+`postInstallNote` is optional (only Codex currently uses it).
 
 ## Version Filtering
 


### PR DESCRIPTION
This PR transitions support from Gemini CLI to the new Antigravity platform. Key changes:
- Target ID renamed to 'antigravity'
- Config directory: .agents (native Antigravity customization folder)
- Commands path: .agents/workflows
- Skills path: .agents/skills
- Rules file: AGENTS.md (cross-tool standard supported by Antigravity)
- Format: Markdown (replacing TOML)
- Updated subagent guidance for Antigravity native tools.